### PR TITLE
Fix wrapper not deleting buf

### DIFF
--- a/Libraries/DirectXTex/wrapper.cpp
+++ b/Libraries/DirectXTex/wrapper.cpp
@@ -267,6 +267,7 @@ namespace DirectXTex
 			// save dds
 			DirectX::SaveToDDSFile(images, image->MipMapLevels, meta, 0, wname);
 
+			delete[] buf;
 			delete[] images;
 		}
 	};


### PR DESCRIPTION
I found this due to attempting to load multiple dds files at once.